### PR TITLE
Fixed composer-plugin constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3",
         "contao/core-bundle": "^3.5.1 || ~4.2",
-        "contao-community-alliance/composer-plugin": "3.*"
+        "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },
     "autoload": {
         "classmap": [""]


### PR DESCRIPTION
Make the new releases Contao `3.5.x` and `4.x` compatible. As stated in https://github.com/contao-community-alliance/composer-plugin#require-the-contao-composer-plugin.